### PR TITLE
Use valid version in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=xbee-api-arduino
-version=0.0a0
+version=0.0.0
 author=UT RAS
 maintainer=UT RAS
 sentence=XBee (Digi) radio ZigBee API mode library


### PR DESCRIPTION
The previous version value caused the Arduino IDE to display warnings:
```
Invalid version found: 0.0a0
```
This warning can be especially confusing for users since the Arduino IDE doesn't say which library is the source of the problem.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format